### PR TITLE
track upstream riak_dt

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [warnings_as_errors, debug_info, {parse_transform, lager_transform}]}.
 {deps, [
         {lager, {git, "git://github.com/basho/lager.git", {tag, "2.1.1"}}},
-        {riak_dt, {git, "git://github.com/helium/riak_dt.git", {tag, "otp17"}}},
+        {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.0"}}},
         {eleveldb, {git, "git://github.com/helium/eleveldb.git", {branch, "adt-helium"}}}
        ]}.
 


### PR DESCRIPTION
Support for OTP 17 landed in riak_dt upstream, under the `2.1.0` tag. This
is the only difference between upstream and the existing helium fork.

Tracking upstream from plumtree is advantageous for obvious reasons,
especially considering the existing open PR to support the Causual LWW
Register, which if merged will provide the same semantics as dvvset.erl,
making it that much easier to provide CRDTs as plumtree_metadata_object's
underlying representation.