### PR TITLE
Flatten NodeStr list in plumtree peer service

### DIFF
--- a/src/plumtree_peer_service.erl
+++ b/src/plumtree_peer_service.erl
@@ -36,7 +36,7 @@ join(Node) ->
 
 %% @doc Convert nodename to atom
 join(NodeStr, Auto) when is_list(NodeStr) ->
-    join(erlang:list_to_atom(NodeStr), Auto);
+    join(erlang:list_to_atom(lists:flatten(NodeStr)), Auto);
 join(Node, Auto) when is_atom(Node) ->
     join(node(), Node, Auto).
 


### PR DESCRIPTION
relx_nodetool rpc passes arguments nested in a list. must flatten.