### PR TITLE
General improvements.

### DIFF
--- a/include/plumtree.hrl
+++ b/include/plumtree.hrl
@@ -1,0 +1,1 @@
+-define(SET, riak_dt_orswot).

--- a/src/plumtree_app.erl
+++ b/src/plumtree_app.erl
@@ -25,7 +25,6 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    _State = plumtree_peer_service_manager:init(),
     case plumtree_sup:start_link() of
         {ok, Pid} ->
             %% do nothing for now

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -116,8 +116,7 @@
 %% to generate membership updates as the ring changes.
 -spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
-    {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
-    Members = ?SET:value(LocalState),
+    {ok, Members} = plumtree_peer_service_manager:members(),
     {InitEagers, InitLazys} = init_peers(Members),
     Mods = app_helper:get_env(plumtree, broadcast_mods, [plumtree_metadata_manager]),
     Res = start_link(Members, InitEagers, InitLazys, Mods),

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -132,7 +132,7 @@ start_link() ->
 %% NOTE: When starting the server using start_link/2 no automatic membership update from
 %% ring_events is registered. Use start_link/0.
 -spec start_link([nodename()], [nodename()], [nodename()], [module()]) ->
-                        {ok, pid()} | ignore | {error, term}.
+    {ok, pid()} | ignore | {error, term()}.
 start_link(InitMembers, InitEagers, InitLazys, Mods) ->
     gen_server:start_link({local, ?SERVER}, ?MODULE,
                           [InitMembers, InitEagers, InitLazys, Mods], []).

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -37,7 +37,6 @@
          debug_get_peers/3,
          debug_get_tree/2]).
 
-
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -216,15 +215,12 @@ debug_get_tree(Root, Nodes) ->
 %%%===================================================================
 
 %% @private
--spec init([[nodename()]]) -> {ok, #state{}} |
-                                  {ok, #state{}, non_neg_integer() | infinity} |
-                                  ignore |
-                                  {stop, term()}.
+-spec init([[any()],...]) -> {ok, #state{}}.
 init([AllMembers, InitEagers, InitLazys, Mods]) ->
     schedule_lazy_tick(),
     schedule_exchange_tick(),
     State1 =  #state{
-                 outstanding   = orddict:new(),
+                 outstanding = orddict:new(),
                  mods = lists:usort(Mods),
                  exchanges=[]
                 },
@@ -232,13 +228,7 @@ init([AllMembers, InitEagers, InitLazys, Mods]) ->
     {ok, State2}.
 
 %% @private
--spec handle_call(term(), {pid(), term()}, #state{}) ->
-                         {reply, term(), #state{}} |
-                         {reply, term(), #state{}, non_neg_integer()} |
-                         {noreply, #state{}} |
-                         {noreply, #state{}, non_neg_integer()} |
-                         {stop, term(), term(), #state{}} |
-                         {stop, term(), #state{}}.
+-spec handle_call(term(), {pid(), term()}, #state{}) -> {reply, term(), #state{}}.
 handle_call({get_peers, Root}, _From, State) ->
     EagerPeers = all_peers(Root, State#state.eager_sets, State#state.common_eagers),
     LazyPeers = all_peers(Root, State#state.lazy_sets, State#state.common_lazys),
@@ -252,9 +242,7 @@ handle_call({cancel_exchanges, WhichExchanges}, _From, State) ->
     {reply, Cancelled, State}.
 
 %% @private
--spec handle_cast(term(), #state{}) -> {noreply, #state{}} |
-                                       {noreply, #state{}, non_neg_integer()} |
-                                       {stop, term(), #state{}}.
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
 handle_cast({broadcast, MessageId, Message, Mod}, State) ->
     State1 = eager_push(MessageId, Message, Mod, State),
     State2 = schedule_lazy_push(MessageId, Mod, State1),
@@ -292,9 +280,8 @@ handle_cast({update, LocalState}, State=#state{all_members=BroadcastMembers}) ->
     {noreply, State2}.
 
 %% @private
--spec handle_info(term(), #state{}) -> {noreply, #state{}} |
-                                       {noreply, #state{}, non_neg_integer()} |
-                                       {stop, term(), #state{}}.
+-spec handle_info('exchange_tick' | 'lazy_tick' | {'DOWN', _, 'process', _, _}, #state{}) ->
+    {noreply, #state{}}.
 handle_info(lazy_tick, State) ->
     schedule_lazy_tick(),
     _ = send_lazy(State),
@@ -463,7 +450,6 @@ exchange_filter({mod, Mod}) ->
     fun({ExchangeMod, _, _, _}) ->
             Mod =:= ExchangeMod
     end.
-
 
 %% picks random root uniformly
 random_root(#state{all_members=Members}) ->

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -38,8 +38,14 @@
          debug_get_tree/2]).
 
 %% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-include("plumtree.hrl").
 
 -define(SERVER, ?MODULE).
 
@@ -111,7 +117,7 @@
 -spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
     {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
-    Members = riak_dt_orswot:value(LocalState),
+    Members = ?SET:value(LocalState),
     {InitEagers, InitLazys} = init_peers(Members),
     Mods = app_helper:get_env(plumtree, broadcast_mods, [plumtree_metadata_manager]),
     Res = start_link(Members, InitEagers, InitLazys, Mods),
@@ -266,7 +272,7 @@ handle_cast({graft, MessageId, Mod, Round, Root, From}, State) ->
     State1 = handle_graft(Result, MessageId, Mod, Round, Root, From, State),
     {noreply, State1};
 handle_cast({update, LocalState}, State=#state{all_members=BroadcastMembers}) ->
-    Members = riak_dt_orswot:value(LocalState),
+    Members = ?SET:value(LocalState),
     CurrentMembers = ordsets:from_list(Members),
     New = ordsets:subtract(CurrentMembers, BroadcastMembers),
     Removed = ordsets:subtract(BroadcastMembers, CurrentMembers),

--- a/src/plumtree_metadata_manager.erl
+++ b/src/plumtree_metadata_manager.erl
@@ -56,9 +56,9 @@
 -include("plumtree_metadata.hrl").
 
 -define(SERVER, ?MODULE).
--define(MANIFEST, cluster_meta_manifest).
--define(MANIFEST_FILENAME, "manifest.dets").
--define(ETS, metadata_manager_prefixes_ets).
+-define(MANIFEST, plumtree_cluster_meta_manifest).
+-define(MANIFEST_FILENAME, "plumtree_meta_manifest.dets").
+-define(ETS, plumtree_metadata_manager_prefixes_ets).
 
 -record(state, {
           %% identifier used in logical clocks

--- a/src/plumtree_metadata_manager.erl
+++ b/src/plumtree_metadata_manager.erl
@@ -321,9 +321,7 @@ exchange(Peer) ->
 
 %% @private
 -spec init([mm_opts()]) -> {ok, #state{}} |
-                           {ok, #state{}, non_neg_integer() | infinity} |
-                           ignore |
-                           {stop, term()}.
+                           {stop, no_data_dir}.
 init([Opts]) ->
     case data_root(Opts) of
         undefined ->
@@ -342,13 +340,7 @@ init([Opts]) ->
     end.
 
 %% @private
--spec handle_call(term(), {pid(), term()}, #state{}) ->
-                         {reply, term(), #state{}} |
-                         {reply, term(), #state{}, non_neg_integer()} |
-                         {noreply, #state{}} |
-                         {noreply, #state{}, non_neg_integer()} |
-                         {stop, term(), term(), #state{}} |
-                         {stop, term(), #state{}}.
+-spec handle_call(term(), {pid(), term()}, #state{}) -> {reply, term(), #state{}}.
 handle_call({put, PKey, Context, ValueOrFun}, _From, State) ->
     {Result, NewState} = read_modify_write(PKey, Context, ValueOrFun, State),
     {reply, Result, NewState};
@@ -382,16 +374,12 @@ handle_call({is_stale, PKey, Context}, _From, State) ->
     {reply, IsStale, State}.
 
 %% @private
--spec handle_cast(term(), #state{}) -> {noreply, #state{}} |
-                                       {noreply, #state{}, non_neg_integer()} |
-                                       {stop, term(), #state{}}.
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
 %% @private
--spec handle_info(term(), #state{}) -> {noreply, #state{}} |
-                                       {noreply, #state{}, non_neg_integer()} |
-                                       {stop, term(), #state{}}.
+-spec handle_info({'DOWN', _, 'process', _, _}, #state{}) -> {noreply, #state{}}.
 handle_info({'DOWN', ItRef, process, _Pid, _Reason}, State) ->
     close_remote_iterator(ItRef, State),
     {noreply, State}.

--- a/src/plumtree_peer_service_console.erl
+++ b/src/plumtree_peer_service_console.erl
@@ -25,8 +25,7 @@
 -include("plumtree.hrl").
 
 members([]) ->
-    {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
-    Members = ?SET:value(LocalState),
+    {ok, Members} = plumtree_peer_service_manager:members(),
     print_members(Members).
 
 print_members(Members) ->

--- a/src/plumtree_peer_service_console.erl
+++ b/src/plumtree_peer_service_console.erl
@@ -22,9 +22,11 @@
 
 -export([members/1]).
 
+-include("plumtree.hrl").
+
 members([]) ->
     {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
-    Members = riak_dt_orswot:value(LocalState),
+    Members = ?SET:value(LocalState),
     print_members(Members).
 
 print_members(Members) ->

--- a/src/plumtree_peer_service_gossip.erl
+++ b/src/plumtree_peer_service_gossip.erl
@@ -24,10 +24,19 @@
 
 -define(GOSSIP_INTERVAL, 15000).
 
--export([start_link/0, stop/0]).
+-export([start_link/0,
+         stop/0]).
+
 -export([receive_state/1]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-        code_change/3]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-include("plumtree.hrl").
 
 %%%==================================================================
 %%% gen_server api
@@ -59,12 +68,12 @@ handle_call(send_state, _From, State) ->
 
 handle_cast({receive_state, PeerState}, State) ->
     {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
-    case riak_dt_orswot:equal(PeerState, LocalState) of
+    case ?SET:equal(PeerState, LocalState) of
         true ->
             %% do nothing
             {noreply, State};
         false ->
-            Merged = riak_dt_orswot:merge(PeerState, LocalState),
+            Merged = ?SET:merge(PeerState, LocalState),
             plumtree_peer_service_manager:update_state(Merged),
             plumtree_peer_service_events:update(Merged),
             {noreply, State}
@@ -103,7 +112,7 @@ do_gossip() ->
 
 %% @doc returns a list of peer nodes
 get_peers(Local) ->
-    Members = riak_dt_orswot:value(Local),
+    Members = ?SET:value(Local),
     Peers = [X || X <- Members, X /= node()],
     Peers.
 

--- a/src/plumtree_peer_service_manager.erl
+++ b/src/plumtree_peer_service_manager.erl
@@ -22,15 +22,60 @@
 
 -define(TBL, cluster_state).
 
--export([init/0,
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
          get_local_state/0,
          get_actor/0,
          update_state/1,
          delete_state/0]).
 
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {}).
+
 -include("plumtree.hrl").
 
-init() ->
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Same as start_link([]).
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @doc Return local node's view of cluster membership.
+get_local_state() ->
+    gen_server:call(?MODULE, get_local_state, infinity).
+
+%% @doc Return local node's current actor.
+get_actor() ->
+    gen_server:call(?MODULE, get_actor, infinity).
+
+%% @doc Update cluster state.
+update_state(State) ->
+    gen_server:call(?MODULE, {update_state, State}, infinity).
+
+%% @doc Delete state.
+delete_state() ->
+    gen_server:call(?MODULE, delete_state, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+-spec init([]) -> {ok, #state{}}.
+init([]) ->
+    lager:info("Initializing..."),
     %% setup ETS table for cluster_state
     _ = try ets:new(?TBL, [named_table, public, set, {keypos, 1}]) of
             _Res ->
@@ -40,48 +85,71 @@ init() ->
         catch
             error:badarg ->
                 lager:warning("Table ~p already exists", [?TBL])
-                %%TODO rejoin logic
         end,
-    ok.
+    {ok, #state{}}.
 
-%% @doc return local node's view of cluster membership
-get_local_state() ->
-   case hd(ets:lookup(?TBL, cluster_state)) of
-       {cluster_state, State} ->
-           {ok, State};
-       _Else ->
-           {error, _Else}
-   end.
-
-%% @doc return local node's current actor
-get_actor() ->
-    case hd(ets:lookup(?TBL, actor)) of
+%% @private
+-spec handle_call(term(), {pid(), term()}, #state{}) -> {reply, term(), #state{}}.
+handle_call(get_local_state, _From, State) ->
+    Result = case hd(ets:lookup(?TBL, cluster_state)) of
+        {cluster_state, ClusterState} ->
+            {ok, ClusterState};
+        _Else ->
+            {error, _Else}
+    end,
+    {reply, Result, State};
+handle_call(get_actor, _From, State) ->
+    Result = case hd(ets:lookup(?TBL, actor)) of
         {actor, Actor} ->
             {ok, Actor};
         _Else ->
             {error, _Else}
-    end.
+    end,
+    {reply, Result, State};
+handle_call({update_state, NewState}, _From, State) ->
+    persist_state(NewState),
+    {reply, ok, State};
+handle_call(delete_state, _From, State) ->
+    delete_state_from_disk(),
+    {reply, ok, State};
+handle_call(Msg, _From, State) ->
+    lager:warning("Unhandled messages: ~p", [Msg]),
+    {reply, ok, State}.
 
-%% @doc update cluster_state
-update_state(State) ->
-    write_state_to_disk(State),
-    ets:insert(?TBL, {cluster_state, State}).
+%% @private
+-spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
+handle_cast(Msg, State) ->
+    lager:warning("Unhandled messages: ~p", [Msg]),
+    {noreply, State}.
 
-delete_state() ->
-    delete_state_from_disk().
+%% @private
+-spec handle_info(term(), #state{}) -> {noreply, #state{}}.
+handle_info(Msg, State) ->
+    lager:warning("Unhandled messages: ~p", [Msg]),
+    {noreply, State}.
 
-%%% ------------------------------------------------------------------
-%%% internal functions
-%%% ------------------------------------------------------------------
+%% @private
+-spec terminate(term(), #state{}) -> term().
+terminate(_Reason, _State) ->
+    ok.
 
-%% @doc initialize singleton cluster
+%% @private
+-spec code_change(term() | {down, term()}, #state{}, term()) -> {ok, #state{}}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% @private
 add_self() ->
     Initial = ?SET:new(),
     Actor = ets:lookup(?TBL, actor),
     {ok, LocalState} = ?SET:update({add, node()}, Actor, Initial),
-    update_state(LocalState).
+    persist_state(LocalState).
 
-%% @doc generate an actor for this node while alive
+%% @private
 gen_actor() ->
     Node = atom_to_list(node()),
     {M, S, U} = now(),
@@ -90,12 +158,16 @@ gen_actor() ->
     Actor = crypto:hash(sha, Term),
     ets:insert(?TBL, {actor, Actor}).
 
+%% @private
 data_root() ->
     case application:get_env(plumtree, plumtree_data_dir) of
-        {ok, PRoot} -> filename:join(PRoot, "peer_service");
-        undefined -> undefined
+        {ok, PRoot} ->
+            filename:join(PRoot, "peer_service");
+        undefined ->
+            undefined
     end.
 
+%% @private
 write_state_to_disk(State) ->
     case data_root() of
         undefined ->
@@ -105,10 +177,10 @@ write_state_to_disk(State) ->
             ok = filelib:ensure_dir(File),
             lager:info("writing state ~p to disk ~p",
                        [State, ?SET:to_binary(State)]),
-            ok = file:write_file(File,
-                                 ?SET:to_binary(State))
+            ok = file:write_file(File, ?SET:to_binary(State))
     end.
 
+%% @private
 delete_state_from_disk() ->
     case data_root() of
         undefined ->
@@ -124,6 +196,7 @@ delete_state_from_disk() ->
             end
     end.
 
+%% @private
 maybe_load_state_from_disk() ->
     case data_root() of
         undefined ->
@@ -131,12 +204,16 @@ maybe_load_state_from_disk() ->
         Dir ->
             case filelib:is_regular(filename:join(Dir, "cluster_state")) of
                 true ->
-                    {ok, Bin} = file:read_file(filename:join(Dir,
-                                                             "cluster_state")),
+                    {ok, Bin} = file:read_file(filename:join(Dir, "cluster_state")),
                     {ok, State} = ?SET:from_binary(Bin),
                     lager:info("read state from file ~p~n", [State]),
-                    update_state(State);
+                    persist_state(State);
                 false ->
                     add_self()
             end
     end.
+
+%% @private
+persist_state(State) ->
+    write_state_to_disk(State),
+    ets:insert(?TBL, {cluster_state, State}).

--- a/src/plumtree_peer_service_manager.erl
+++ b/src/plumtree_peer_service_manager.erl
@@ -94,9 +94,10 @@ handle_call(get_local_state, _From, #state{membership=Membership}=State) ->
     {reply, {ok, Membership}, State};
 handle_call(get_actor, _From, #state{actor=Actor}=State) ->
     {reply, {ok, Actor}, State};
-handle_call({update_state, NewState}, _From, State) ->
-    persist_state(NewState),
-    {reply, ok, State#state{membership=NewState}};
+handle_call({update_state, NewState}, _From, #state{membership=Membership}=State) ->
+    Merged = ?SET:merge(Membership, NewState),
+    persist_state(Merged),
+    {reply, ok, State#state{membership=Merged}};
 handle_call(delete_state, _From, State) ->
     delete_state_from_disk(),
     {reply, ok, State};

--- a/src/plumtree_sup.erl
+++ b/src/plumtree_sup.erl
@@ -35,6 +35,7 @@ start_link() ->
 init([]) ->
     Children = lists:flatten(
                  [
+                 ?CHILD(plumtree_peer_service_manager, worker),
                  ?CHILD(plumtree_peer_service_gossip, worker),
                  ?CHILD(plumtree_peer_service_events, worker),
                  ?CHILD(plumtree_broadcast, worker),

--- a/test/plumtree_test_utils.erl
+++ b/test/plumtree_test_utils.erl
@@ -20,22 +20,23 @@
 
 -module(plumtree_test_utils).
 
--export([
-    get_cluster_members/1,
-    pmap/2,
-    wait_until/3,
-    wait_until_left/2,
-    wait_until_joined/2,
-    wait_until_offline/1,
-    wait_until_disconnected/2,
-    wait_until_connected/2,
-    start_node/3,
-    partition_cluster/2,
-    heal_cluster/2
-    ]).
+-export([get_cluster_members/1,
+         pmap/2,
+         wait_until/3,
+         wait_until_left/2,
+         wait_until_joined/2,
+         wait_until_offline/1,
+         wait_until_disconnected/2,
+         wait_until_connected/2,
+         start_node/3,
+         partition_cluster/2,
+         heal_cluster/2]).
+
+-include("plumtree.hrl").
+
 get_cluster_members(Node) ->
     {Node, {ok, Res}} = {Node, rpc:call(Node, plumtree_peer_service_manager, get_local_state, [])},
-    riak_dt_orswot:value(Res).
+    ?SET:value(Res).
 
 pmap(F, L) ->
     Parent = self(),


### PR DESCRIPTION
Here's a set of general improvements made to Plumtree to in building support for Plumtree into the Lasp programming language.  These changes resolve a series of Dialyzer warnings, address race conditions in creation of local state, and local mutations of membership state.

I tested these changes under Erlang 16 (with additional patches not included in this PR), but was unable to get the common test suite to run, so I was unable to verify that.

Comments welcome.