### PR TITLE
include lasp_support and time_compat on start

### DIFF
--- a/src/plumtree.app.src
+++ b/src/plumtree.app.src
@@ -9,7 +9,9 @@
                   crypto,
                   lager,
                   eleveldb,
-                  riak_dt
+                  riak_dt,
+                  time_compat,
+                  lasp_support
                  ]},
   {mod, { plumtree_app, []}},
   {modules, []},


### PR DESCRIPTION
remnant of merging https://github.com/helium/plumtree/pull/26, plumtree or any application which depends on plumtree must also load `time_compat` and `lasp_support`