### PR TITLE
Ensure membership is recomputed.

### DIFF
--- a/src/plumtree_peer_service.erl
+++ b/src/plumtree_peer_service.erl
@@ -62,6 +62,7 @@ attempt_join(Node, Local) ->
     {ok, Remote} = gen_server:call({plumtree_peer_service_gossip, Node}, send_state),
     Merged = ?SET:merge(Remote, Local),
     _ = plumtree_peer_service_manager:update_state(Merged),
+    plumtree_peer_service_events:update(Merged),
     %% broadcast to all nodes
     %% get peer list
     Members = ?SET:value(Merged),


### PR DESCRIPTION
Ensure that membership locally, at the node coordinating the join
command, is updated.  Otherwise, if not, this node will show a set of
peers that will never be incorporated into the broadcast modules
spanning tree.  Therefore, anti-entropy exchanges will never occur
because the eager and lazy set will contain no peers.

(and subsequently, this node will never broadcast to any of 
those peers, either.)

Unfortunately, I don't have a standalone test for this yet, because 
this was discovered as part of the Lasp integration suite.  I can try 
to write one later, but this was discovered three days before a 
paper deadline, so don't expect it to happen before then.