### PR TITLE
Pin dependencies.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
-        {lasp_support, ".*", {git, "git://github.com/lasp-lang/lasp_support.git", {branch, "master"}}},
-        {time_compat, ".*", {git, "git://github.com/lasp-lang/time_compat.git", {branch, "master"}}},
+        {lasp_support, ".*", {git, "git://github.com/lasp-lang/lasp_support.git", {tag, "0.0.1"}}},
+        {time_compat, ".*", {git, "git://github.com/lasp-lang/time_compat.git", {tag, "0.0.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "2.1.1"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.0"}}},
         {eleveldb, ".*", {git, "git://github.com/helium/eleveldb.git", {branch, "adt-helium"}}}


### PR DESCRIPTION
Pin dependencies to prevent deprecations from stopping build.