### PR TITLE
Don't throw error if no handlers are available.

### DIFF
--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -407,7 +407,10 @@ maybe_exchange(Peer, State=#state{mods=[Mod | _],exchanges=Exchanges}) ->
     case BelowLimit and FreeMod of
         true -> exchange(Peer, State);
         false -> State
-    end.
+    end;
+maybe_exchange(_Peer, State=#state{mods=[]}) ->
+    %% No registered handler.
+    State.
 
 exchange(Peer, State=#state{mods=[Mod | Mods],exchanges=Exchanges}) ->
     State1 = case Mod:exchange(Peer) of


### PR DESCRIPTION
If there is no handler available, don't crash plumtree when attempting
to exchange.  When removing the default handler, any app that depends on
plumtree can trigger this behaviour when it stops/starts because it will
remove it's own handler, first.