### PR TITLE
Update the eleveldb dependency

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"eleveldb">>,
   {git,"git://github.com/helium/eleveldb.git",
-       {ref,"4e199ab1518060d348ae0f9719d2cbf9f098e00d"}},
+       {ref,"7ae3114306fe564152e245157cb38cf39b383995"}},
   0},
  {<<"goldrush">>,
   {git,"git://github.com/DeadZen/goldrush.git",


### PR DESCRIPTION
Update the eleveldb dependency to pull in a change to pin the leveldb
dependncy to the 2.0.0 tag instead of the 2.0 branch. The 2.0 branch
build of leveldb appears to have broken and necessitated this change.